### PR TITLE
bugfix: fix incorrect dynamic array marshalling

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -20,6 +20,11 @@ jobs:
         fetch-depth: 0
         submodules: recursive
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '6.0.x'
+
     - name: Restore .NET tools
       working-directory: ${{github.workspace}}
       run: dotnet tool restore

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,6 +21,12 @@ jobs:
       with:
         fetch-depth: 0
         submodules: recursive 
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '6.0.x'
+
     - name: Restore .NET tools
       working-directory: ${{github.workspace}}
       run: dotnet tool restore

--- a/SharpGen/Generator/Marshallers/RemappedTypeMarshaller.cs
+++ b/SharpGen/Generator/Marshallers/RemappedTypeMarshaller.cs
@@ -9,7 +9,7 @@ namespace SharpGen.Generator.Marshallers;
 
 internal sealed class RemappedTypeMarshaller : MarshallerBase, IMarshaller
 {
-    public bool CanMarshal(CsMarshalBase csElement) => csElement.MappedToDifferentPublicType;
+    public bool CanMarshal(CsMarshalBase csElement) => csElement.MappedToDifferentPublicType && !csElement.IsArray;
 
     public ArgumentSyntax GenerateManagedArgument(CsParameter csElement) =>
         GenerateManagedValueTypeArgument(csElement);


### PR DESCRIPTION
Related: https://github.com/DiligentGraphics/DiligentCore/issues/766

**Root Cause & Context:**
When a user configures `<map override-native-type="true" />` for an array field (e.g., mapping `byte[]` to a different native type), two cascading issues occur:
1.  **Incorrect Marshaller Selection**: `RemappedTypeMarshaller` incorrectly claimed responsibility for the field. Since it lacks array handling capabilities, it generated code that completely missed the array marshalling logic.
2.  **Defective Dynamic Array Logic**: Even when `ValueTypeArrayMarshaller` was correctly forced to handle the field, its implementation for Dynamic Arrays was flawed:
    *   **Memory Corruption**: It reused `GenerateCopyMemory` (designed for Constant Arrays), which unconditionally took the address of the target field (`&@ref.Ptr`). For dynamic arrays (which are pointers), this caused the marshaller to overwrite the pointer variable itself and adjacent struct fields (e.g., array length), leading to Access Violations.
    *   **Missing Logic**: It failed to generate code to assign the managed array's length to the native struct's length field (defined by `LengthRelation`), leaving the native API with a zero or uninitialized length.

**Fix:**
1.  **Correct Marshaller Routing**:
    *   Modified `RemappedTypeMarshaller.CanMarshal` to explicitly **exclude array types**, preventing incorrect interception.
    *   Modified `ValueTypeArrayMarshaller.CanMarshal` to **allow** handling of fields that are mapped to different public types (`MappedToDifferentPublicType`).
2.  **Fix Memory Corruption**:
    *   Refactored `GenerateCopyMemory` to accept a `bool takeAddress` parameter.
    *   For Dynamic Arrays, passed `takeAddress = false` to use the pointer directly as the destination, bypassing the incorrect address-taking.
3.  **Complete Length Assignment**:
    *   Added the missing logic to assign the array length to the corresponding native length field (based on `ArraySpecification`) during dynamic array marshalling.